### PR TITLE
Fix concatenation type errors

### DIFF
--- a/collector/aws.py
+++ b/collector/aws.py
@@ -101,9 +101,9 @@ class aws:
                         # Collect AWS Congnito
                         # Collect ELBv2
 
-                        click.echo("Completed collecting Infrastructure details from the account -  " + aws_account + "in the region - " + r)
+                        click.echo("Completed collecting Infrastructure details from the account -  " + str(aws_account) + "in the region - " + r)
                     except KeyError:
                         continue
             else:
-                print(f'Please check the AWS Account number {aws_account}. It does seem to be valid.')
+                print(f'Please check the AWS Account number {str(aws_account)}. It does seem to be valid.')
         return infradata

--- a/findmytakeover.py
+++ b/findmytakeover.py
@@ -146,7 +146,7 @@ def main():
 
     for i in result.index:
         if result['value'][i] == "":
-            click.echo("Found dangling DNS record - " + result["dnskey"][i] + " with the value "+ result["dnsvalue"][i] + " in " + result["csp_x"][i] + " cloud in the account/subscription/project - " + result["account_x"][i])
+            click.echo("Found dangling DNS record - " + str(result["dnskey"][i]) + " with the value "+ str(result["dnsvalue"][i]) + " in " + str(result["csp_x"][i]) + " cloud in the account/subscription/project - " + str(result["account_x"][i]))
     
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Ran into a few type errors when running against AWS, such as:

- TypeError: can only concatenate str (not "numpy.int64") to str
- TypeError: can only concatenate str (not "int") to str