### PR TITLE
Add Claude Code skill: dangling-dns-finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ infra:
       - subscription3
 ```
 
+## Claude skill
+A [Claude Code](https://docs.claude.com/en/docs/claude-code) skill is bundled under [`skills/dangling-dns-finder`](skills/dangling-dns-finder). It lets you run a dangling-DNS / subdomain-takeover audit conversationally ("find dangling domains in `example.com`") against a Route53 zone, with NXDOMAIN checks verified across multiple resolvers, cloud-inventory cross-referencing, HTTP liveness confirmation, and a ready-to-review Route53 delete batch. See its [SKILL.md](skills/dangling-dns-finder/SKILL.md) for usage.
+
 ## Limtitations 
 This tools cannot guarantee 100% protection against subdomain takeovers. This will not protect you from dangling NS designations at the moment.
 

--- a/skills/dangling-dns-finder/SKILL.md
+++ b/skills/dangling-dns-finder/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: dangling-dns-finder
+description: >-
+  Detect dangling DNS records and subdomain-takeover risks in a DNS zone. Use
+  whenever the user wants to find dangling domains/records, stale CNAMEs,
+  subdomain takeover exposure, orphaned DNS entries, or audit a DNS zone (e.g.
+  cloud.prophecy.io, example.com) for records pointing at deleted cloud
+  resources — dead load balancers (ELBs), released EC2/GCP/Azure IPs, or expired
+  SaaS targets. Triggers on "dangling domains", "dangling DNS", "subdomain
+  takeover", "audit my DNS zone", "find stale/orphaned DNS records", "dead
+  CNAMEs", or pointing at a Route53 zone and asking what's safe to delete. Works
+  for ANY zone the user can dump (Route53 by default; bring-your-own records JSON
+  otherwise).
+---
+
+# Dangling DNS Finder
+
+Find DNS records that point at resources that no longer exist — the classic
+subdomain-takeover setup. A `CNAME` to a deleted ELB or a SaaS tenant that was
+cancelled, or an `A` record to a released cloud IP, can be silently reclaimed by
+someone else and used to serve content under your domain.
+
+## What counts as "dangling"
+
+Two distinct, verifiable signals — keep them separate, they have different
+confidence and different remediation:
+
+1. **CNAME / ALIAS → NXDOMAIN.** The target hostname no longer resolves *at
+   all*. For AWS this is definitive: if an ELB existed in any account, AWS's own
+   authoritative DNS would answer. NXDOMAIN = the backing resource is gone.
+   **High confidence.**
+2. **A record → IP that isn't yours and doesn't respond.** The IP is absent from
+   your cloud inventory (no EIP/ENI/static-address/instance owns it) *and* it
+   doesn't answer HTTP. **Medium-high confidence** — see the caveats, this one
+   has more ways to be wrong.
+
+## Workflow
+
+Run the bundled scripts in order. They are bash (run via `bash script.sh`, not
+zsh — see Pitfalls). All write to an output dir you pass.
+
+### 1. Scan the zone
+
+```bash
+bash scripts/find_dangling.sh <zone_name> <aws_profile> [outdir]
+# e.g. bash scripts/find_dangling.sh cloud.prophecy.io dns ./out
+```
+
+This finds the Route53 hosted zone, dumps all records to `<outdir>/records.json`,
+then:
+- Resolves every CNAME/ALIAS target. NXDOMAIN is **re-checked against 8.8.8.8 and
+  1.1.1.1** before being trusted (a single resolver can flake). → `dangling_cname.tsv`
+- Categorizes each target so validation records aren't misreported as takeovers
+  (see Classification). → category column
+- HTTP-probes every A-record host; no response = candidate. → `dangling_a.tsv`
+
+If the zone is **not** in Route53, skip the dump and hand the script a records
+JSON in the same shape (`{"ResourceRecordSets":[...]}`) — or just run the
+resolution/liveness logic against a list of names you already have.
+
+### 2. (Recommended) Confirm A-record candidates against cloud inventory
+
+Liveness alone is a heuristic. For real confidence on A records, cross-reference
+the IPs against what your accounts actually own:
+
+```bash
+bash scripts/audit_a_inventory.sh <outdir> [aws_profiles] [gcp] [azure]
+# e.g. bash scripts/audit_a_inventory.sh ./out "dns prof-prod staging" yes yes
+```
+
+An A-record IP that is **both** absent from every account's inventory **and**
+unreachable over HTTP is a genuine dangling candidate. An IP that responds — even
+404 — is in use (often via a load-balancer/forwarding-rule IP that doesn't show
+up in a plain instance/EIP listing), so treat it as live and keep it.
+
+### 3. Report
+
+Present a single consolidated table: **IP/Target · Cloud · Subdomain**, grouped
+by category, with counts. State confidence per bucket and call out anything
+sensitive (customer-named subdomains, `*-prod` hosts) for manual confirmation
+before deletion.
+
+### 4. Generate the delete command (show, don't run)
+
+```bash
+bash scripts/build_delete_batch.sh <outdir>/records.json <names.txt> <outdir>/delete-batch.json
+```
+
+`names.txt` = one FQDN per line **with trailing dot**, matching record names
+(`find_dangling.sh` writes `dangling_names.txt` for the takeover-risk set and
+`validation_names.txt` for stale validation records). Then show the user:
+
+```bash
+aws route53 change-resource-record-sets \
+  --hosted-zone-id <ZID> \
+  --change-batch file://<outdir>/delete-batch.json \
+  --profile <profile>
+```
+
+Default to **showing** the command and letting the user run it. DNS deletion is
+hard to reverse and outward-facing — only run it yourself if the user explicitly
+says so. The build step prints a count; it must equal your name list before the
+delete is safe to run.
+
+## Classification — what is NOT a takeover risk
+
+Plenty of records resolve to nothing or look dead but are harmless. Don't report
+these as dangling domains; bucket them separately as "stale, optional cleanup":
+
+- **ACM cert validation** — CNAME → `*.acm-validations.aws`. Normal; resolves to
+  no A record. Stale only if the cert is gone.
+- **Google cert-manager validation** — CNAME → `*.authorize.certificatemanager.goog`.
+  `_acme-challenge_*` names. Single-use DNS-01 tokens, **not** service endpoints —
+  even when NXDOMAIN they are not a takeover vector.
+- **DKIM / email auth** — CNAME → `*.dkim.*`, `*.custdkim.salesforce.com`,
+  `*.hubspotemail.net`, `*.domainkey.*`, `*.deliver.highspot.com`, `freshemail.io`.
+  These point into live SaaS provider zones; `NOERROR` with no A record is expected.
+- **MX / TXT / NS / SOA** — out of scope; never delete as part of this.
+
+Only a CNAME/ALIAS whose target is a real endpoint (ELB, cloud host, app) AND
+returns NXDOMAIN is a takeover risk.
+
+## Pitfalls (these cost real time — heed them)
+
+- **Run scripts with `bash`, not zsh.** In zsh `status` is a read-only variable;
+  a loop doing `status=$(...)` dies instantly. The scripts use `bash` shebangs and
+  the var name `st` — keep it that way.
+- **macOS has no `timeout`/`gtimeout`.** Don't rely on it. Use `curl -m <secs>`
+  for bounded network calls (the scripts do).
+- **Raw `/dev/tcp` port probes are often blocked** outbound from a dev machine —
+  they return uniform failure and look like "everything is dead." Use `curl -m`
+  for liveness, and sanity-check the probe against a known-live host first.
+- **"Not in my cloud inventory" ≠ dangling for GCP/Azure.** Plain
+  instance/address listings miss GKE/LB forwarding-rule IPs and any project you
+  lack read access to. Always confirm with an HTTP liveness probe; an IP that
+  answers is in use even if your inventory sweep didn't find it.
+- **A live VM firewalled from you can false-positive as dead.** If the whole
+  inventory of live IPs also responds, blanket-firewalling isn't happening and
+  confidence is high — but still spot-check `*-prod` / customer hosts before
+  deleting.
+- **Escaped record names** (e.g. `\100.example.com`, octal/decimal escapes,
+  wildcards `\052` = `*`) break naive `curl` probes — the script skips them; verify
+  those by reading the record's value directly (`dig` / the zone dump), don't
+  assume dead.
+- **Verify NXDOMAIN across multiple resolvers** (8.8.8.8 + 1.1.1.1) before
+  trusting it. The script does this for you.
+- **Zones can live in different accounts/profiles.** Don't assume one profile
+  owns every zone — look the zone up per profile, and run the delete with the
+  profile that actually owns it.
+- **`build_delete_batch.sh` matches by name**, so it removes *all* record types
+  at a matched name. That's fine for single-type danglers; if a dangling name
+  also carries a record you want to keep (e.g. a TXT), edit the batch by hand.
+
+## Self-check
+
+`bash scripts/selftest.sh` asserts the target classifier (ACM / cert-manager /
+DKIM / endpoint) still buckets correctly. Run it after editing the classifier.

--- a/skills/dangling-dns-finder/scripts/audit_a_inventory.sh
+++ b/skills/dangling-dns-finder/scripts/audit_a_inventory.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Cross-reference A-record IPs against cloud inventory you actually own, so a
+# "no HTTP response" candidate is only called dangling when it's ALSO not owned.
+# Usage: bash audit_a_inventory.sh <outdir> [aws_profiles] [gcp] [azure]
+#   <outdir>      dir produced by find_dangling.sh (needs a_records.tsv)
+#   aws_profiles  space-separated, quoted, e.g. "dns prof-prod staging" (default: none)
+#   gcp           "yes" to sweep all gcloud projects (needs gcloud auth)
+#   azure         "yes" to sweep all az subscriptions (needs az login)
+set -uo pipefail
+OUT="${1:?outdir from find_dangling.sh}"
+AWS_PROFILES="${2:-}"
+DO_GCP="${3:-no}"
+DO_AZURE="${4:-no}"
+REGIONS="${REGIONS:-us-east-1 us-east-2 us-west-1 us-west-2 sa-east-1 eu-west-1 ap-south-1}"
+[ -f "$OUT/a_records.tsv" ] || { echo "missing $OUT/a_records.tsv — run find_dangling.sh first"; exit 1; }
+
+OWNED="$OUT/owned_ips.txt"; : > "$OWNED"
+
+for p in $AWS_PROFILES; do
+  for r in $REGIONS; do
+    aws ec2 describe-network-interfaces --profile "$p" --region "$r" \
+      --query 'NetworkInterfaces[].Association.PublicIp' --output text 2>/dev/null | tr '\t' '\n' >> "$OWNED"
+    aws ec2 describe-addresses --profile "$p" --region "$r" \
+      --query 'Addresses[].PublicIp' --output text 2>/dev/null | tr '\t' '\n' >> "$OWNED"
+  done
+  echo "  swept aws:$p" >&2
+done
+
+if [ "$DO_GCP" = yes ]; then
+  for proj in $(gcloud projects list --format="value(projectId)" 2>/dev/null); do
+    gcloud compute addresses list --project "$proj" --format="value(address)" 2>/dev/null >> "$OWNED"
+    gcloud compute instances list --project "$proj" \
+      --format="value(networkInterfaces[].accessConfigs[].natIP)" 2>/dev/null | tr ';,' '\n' >> "$OWNED"
+    echo "  swept gcp:$proj" >&2
+  done
+fi
+
+if [ "$DO_AZURE" = yes ]; then
+  for sub in $(az account list --query "[].id" -o tsv 2>/dev/null); do
+    az network public-ip list --subscription "$sub" --query "[].ipAddress" -o tsv 2>/dev/null >> "$OWNED"
+    echo "  swept azure:$sub" >&2
+  done
+fi
+
+grep -E '^[0-9]+\.' "$OWNED" | sort -u > "$OUT/owned_sorted.txt"
+echo "Owned public IPs found: $(wc -l < "$OUT/owned_sorted.txt")"
+
+# Verdict: an A-record IP is a dangling candidate only if NOT owned. Combine with
+# the no-HTTP signal from find_dangling (dangling_a.tsv) for high confidence.
+echo
+echo "=== A-record IP ownership (NOT-FOUND + no-HTTP = dangling) ==="
+awk '{print $2}' "$OUT/a_records.tsv" | sort -u | while read -r ip; do
+  grep -qx "$ip" "$OUT/owned_sorted.txt" && v=OWNED || v=NOT-FOUND
+  nohttp=""; grep -q "^$ip	" "$OUT/dangling_a.tsv" 2>/dev/null && nohttp="no-HTTP"
+  hosts=$(awk -v ip="$ip" '$2==ip{printf "%s ",$1}' "$OUT/a_records.tsv")
+  printf '%-16s %-10s %-8s %s\n' "$ip" "$v" "$nohttp" "$hosts"
+done | sort -k2,2 -k3,3

--- a/skills/dangling-dns-finder/scripts/build_delete_batch.sh
+++ b/skills/dangling-dns-finder/scripts/build_delete_batch.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Build a Route53 change-batch that DELETEs the named records, sourcing exact
+# TTL/values from the live zone dump (DELETE requires an exact match).
+# Usage: bash build_delete_batch.sh <records.json> <names.txt> [out.json]
+#   names.txt = one FQDN per line, WITH trailing dot, matching record .Name
+# NOTE: matches by name, so it deletes ALL record types at a matched name.
+#       If a dangling name also carries a record you want to keep, edit by hand.
+set -euo pipefail
+REC="${1:?records.json}"; NAMES="${2:?names.txt}"; OUT="${3:-delete-batch.json}"
+
+jq --rawfile names "$NAMES" '
+  ($names | split("\n") | map(select(length>0))) as $del
+  | {Changes: [ .ResourceRecordSets[]
+      | select(.Name as $n | $del | index($n))
+      | {Action:"DELETE", ResourceRecordSet: .} ]}' "$REC" > "$OUT"
+
+got=$(jq '.Changes|length' "$OUT"); want=$(grep -c . "$NAMES")
+echo "Changes in batch: $got   (names requested: $want)"
+[ "$got" = "$want" ] || echo "WARNING: count mismatch — names didn't all match the dump. Don't apply until resolved."
+echo
+echo "Apply (review first; this is hard to reverse):"
+echo "  aws route53 change-resource-record-sets --hosted-zone-id <ZID> --change-batch file://$OUT --profile <PROFILE>"

--- a/skills/dangling-dns-finder/scripts/find_dangling.sh
+++ b/skills/dangling-dns-finder/scripts/find_dangling.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Find dangling / subdomain-takeover-prone records in a Route53 hosted zone.
+# Usage: bash find_dangling.sh <zone_name> <aws_profile> [outdir]
+#   e.g. bash find_dangling.sh cloud.prophecy.io dns ./out
+# If the zone isn't in Route53, drop your own {"ResourceRecordSets":[...]} at
+# <outdir>/records.json and set ZID=skip:  ZID=skip bash find_dangling.sh <zone> <profile> <outdir>
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; . "$HERE/lib.sh"
+
+ZONE="${1:?zone name, e.g. example.com}"
+PROFILE="${2:?aws profile}"
+OUT="${3:-./dangling-$ZONE}"
+mkdir -p "$OUT"
+
+# 1. locate zone + dump records (unless caller supplied records.json with ZID=skip)
+if [ "${ZID:-}" != "skip" ]; then
+  ZID=$(aws route53 list-hosted-zones --profile "$PROFILE" \
+        --query "HostedZones[?Name=='${ZONE}.'].Id" --output text 2>/dev/null \
+        | tr '\t' '\n' | head -1 | sed 's#/hostedzone/##')
+  [ -z "${ZID:-}" ] && { echo "Zone '$ZONE' not found in profile '$PROFILE'."; exit 1; }
+  aws route53 list-resource-record-sets --hosted-zone-id "$ZID" --profile "$PROFILE" \
+    --output json > "$OUT/records.json" || { echo "Failed to dump zone."; exit 1; }
+fi
+echo "Zone: $ZONE (${ZID:-supplied})  records: $(jq '.ResourceRecordSets|length' "$OUT/records.json")"
+
+# 2. CNAME + ALIAS targets -> NXDOMAIN (verified x3), categorized
+jq -r '.ResourceRecordSets[]
+  | select(.Type=="CNAME" or (.Type=="A" and .AliasTarget!=null))
+  | if .Type=="CNAME" then "\(.Name)\tCNAME\t\(.ResourceRecords[0].Value)"
+    else "\(.Name)\tALIAS\t\(.AliasTarget.DNSName)" end' "$OUT/records.json" \
+  | sed 's/\.$//' > "$OUT/targets.tsv"
+
+: > "$OUT/dangling_cname.tsv"
+while IFS=$'\t' read -r name type target; do
+  [ -z "$target" ] && continue
+  st=$(dig_status "$target")
+  [ "$st" != NXDOMAIN ] && continue
+  # re-verify on public resolvers to avoid single-resolver flukes
+  [ "$(dig_status "$target" 8.8.8.8)" = NXDOMAIN ] || continue
+  [ "$(dig_status "$target" 1.1.1.1)" = NXDOMAIN ] || continue
+  printf '%s\t%s\t%s\n' "$target" "$(classify_target "$target")" "$name" >> "$OUT/dangling_cname.tsv"
+done < "$OUT/targets.tsv"
+
+# 3. A records -> HTTP liveness probe (portable, no cloud creds needed)
+jq -r '.ResourceRecordSets[]|select(.Type=="A" and .ResourceRecords!=null)
+       | .Name as $n | .ResourceRecords[] | "\($n)\t\(.Value)"' "$OUT/records.json" \
+  | sed 's/\.\t/\t/' > "$OUT/a_records.tsv"
+
+: > "$OUT/dangling_a.tsv"
+cut -f1 "$OUT/a_records.tsv" | sort -u | while read -r host; do
+  case "$host" in *'\'*) continue ;; esac   # escaped names break curl; verify by hand
+  code=$(curl -sS -k -m 8 -o /dev/null -w '%{http_code}' "https://$host/" 2>/dev/null); rc=$?
+  { [ "$rc" != 0 ] || [ "$code" = 000 ]; } && code=DEAD
+  [ "$code" != DEAD ] && continue
+  ip=$(awk -v n="$host" '$1==n{print $2}' "$OUT/a_records.tsv" | head -1)
+  printf '%s\t%s\tno-HTTP\n' "$ip" "$host" >> "$OUT/dangling_a.tsv"
+done
+
+# 4. report + name lists for deletion
+echo
+echo "=== DANGLING CNAME/ALIAS  (target | category | name) — endpoint = takeover risk ==="
+sort -t$'\t' -k2 "$OUT/dangling_cname.tsv" 2>/dev/null | column -s$'\t' -t || true
+echo
+echo "=== A RECORDS WITH NO HTTP RESPONSE (candidates — confirm with audit_a_inventory.sh) ==="
+column -s$'\t' -t "$OUT/dangling_a.tsv" 2>/dev/null || true
+
+{ awk -F'\t' '$2=="endpoint"{print $3}' "$OUT/dangling_cname.tsv"
+  awk -F'\t' '{print $2}' "$OUT/dangling_a.tsv"; } | sed 's/\.*$/./' | sort -u > "$OUT/dangling_names.txt"
+awk -F'\t' '$2!="endpoint"{print $3}' "$OUT/dangling_cname.tsv" | sed 's/\.*$/./' | sort -u > "$OUT/validation_names.txt"
+
+echo
+echo "Wrote:"
+echo "  $OUT/dangling_names.txt    -> $(grep -c . "$OUT/dangling_names.txt" 2>/dev/null || echo 0) takeover-risk names"
+echo "  $OUT/validation_names.txt  -> $(grep -c . "$OUT/validation_names.txt" 2>/dev/null || echo 0) stale validation (optional cleanup)"
+echo "Next: bash audit_a_inventory.sh $OUT \"$PROFILE\"   then   build_delete_batch.sh $OUT/records.json <names> $OUT/delete-batch.json"

--- a/skills/dangling-dns-finder/scripts/lib.sh
+++ b/skills/dangling-dns-finder/scripts/lib.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Shared helpers for the dangling-dns-finder scripts.
+
+# classify_target <target-hostname> -> echoes one of:
+#   cert-validation | dkim | endpoint
+# Validation/DKIM targets are NOT subdomain-takeover risks even when NXDOMAIN
+# (single-use tokens / live SaaS provider zones). Only "endpoint" matters.
+classify_target() {
+  case "$1" in
+    *acm-validations.aws|*acm-validations.aws.) echo cert-validation ;;
+    *certificatemanager.goog|*certificatemanager.goog.) echo cert-validation ;;
+    *dkim*|*domainkey*|*custdkim*|*hubspotemail.net*|*deliver.highspot.com*|*freshemail.io*) echo dkim ;;
+    *) echo endpoint ;;
+  esac
+}
+
+# dig_status <name> [resolver] -> echoes NXDOMAIN/NOERROR/SERVFAIL/... or NORESP
+dig_status() {
+  local r=""
+  [ -n "${2:-}" ] && r="@$2"
+  dig $r +noall +comments "$1" A 2>/dev/null \
+    | grep -oE 'status: [A-Z]+' | head -1 | awk '{print $2}' | grep . || echo NORESP
+}

--- a/skills/dangling-dns-finder/scripts/selftest.sh
+++ b/skills/dangling-dns-finder/scripts/selftest.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Self-check for the target classifier — the one bit of non-trivial logic that,
+# if it breaks, silently mislabels validation records as takeover risks.
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; . "$HERE/lib.sh"
+
+check() { # check <target> <expected>
+  got=$(classify_target "$1")
+  [ "$got" = "$2" ] || { echo "FAIL: $1 -> $got (expected $2)"; exit 1; }
+}
+
+check "_x.vybhcgkthd.acm-validations.aws"                 cert-validation
+check "abc.1.us-west1.authorize.certificatemanager.goog" cert-validation
+check "prophecy-io.hs18a.dkim.hubspotemail.net"          dkim
+check "prophecy.io.48fps4.custdkim.salesforce.com"       dkim
+check "wl414215s1.domainkey.freshemail.io"               dkim
+check "hsp.prophecy.deliver.highspot.com"                dkim
+check "a86a5d73.us-east-1.elb.amazonaws.com"             endpoint
+check "k8s-prophecy-prophecy-x.elb.us-west-1.amazonaws.com" endpoint
+check "some-vm.example.com"                              endpoint
+
+echo "OK: classifier self-check passed (9 cases)"


### PR DESCRIPTION
## What

Adds a [Claude Code](https://docs.claude.com/en/docs/claude-code) skill under `skills/dangling-dns-finder/` so the dangling-DNS / subdomain-takeover audit can be driven conversationally (e.g. *"find dangling domains in example.com"*) alongside the existing Python CLI.

## What it does

- **CNAME/ALIAS → NXDOMAIN** detection, re-verified across `8.8.8.8` + `1.1.1.1` to avoid single-resolver flukes.
- **A-record audit**: cross-references record IPs against AWS/GCP/Azure inventory you own, then confirms with an HTTP liveness probe (an IP that answers is in use even if an inventory sweep missed it — e.g. GKE/LB forwarding-rule IPs).
- **Classifies validation records** (ACM `acm-validations.aws`, Google cert-manager `_acme-challenge`, DKIM) as *not* takeover risks, so they aren't false-flagged.
- **Generates a reviewable Route53 delete change-batch** — never auto-applies.

## Contents

```
skills/dangling-dns-finder/
├── SKILL.md                      # workflow, classification rules, pitfalls
└── scripts/
    ├── find_dangling.sh          # zone dump + CNAME NXDOMAIN + A liveness
    ├── audit_a_inventory.sh      # A-record IP cross-ref vs AWS/GCP/Azure
    ├── build_delete_batch.sh     # Route53 DELETE change-batch from a names file
    ├── lib.sh                    # shared classifier + dig helper
    └── selftest.sh               # asserts the validation/DKIM/endpoint classifier
```

README links to the skill. `selftest.sh` passes (9 classifier cases). No changes to the existing tool.