### PR TITLE
feat: add Dockerfile and PyPI publish workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,12 +1,32 @@
+# VCS / CI
 .git
 .github
+.gitignore
+.dockerignore
+
+# Python build/cache artifacts
 __pycache__/
-*.pyc
-*.pyo
-dist/
-build/
+*.py[cod]
 *.egg-info/
+build/
+dist/
+.pytest_cache/
+.mypy_cache/
+
+# Virtualenvs
+.venv
+venv/
+env/
+ENV/
+
+# Secrets / local config / scan output — must never enter the image
+.env
+findmytakeover.config
+scan-dump.csv
+*.csv
+*.log
+
+# Docs / assets not needed at runtime
 docs/
 tests/
 findmytakeover.jpg
-.gitignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+__pycache__/
+*.pyc
+*.pyo
+dist/
+build/
+*.egg-info/
+docs/
+tests/
+findmytakeover.jpg
+.gitignore

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,44 @@
+name: Docker
+
+# Build (and smoke-test) the image whenever anything that affects it changes.
+on:
+  push:
+    branches: [main]
+    paths: &img_paths
+      - "Dockerfile"
+      - ".dockerignore"
+      - "pyproject.toml"
+      - "findmytakeover.py"
+      - "collector/**"
+      - ".github/workflows/docker.yml"
+  pull_request:
+    paths: *img_paths
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Read version from pyproject.toml
+        id: ver
+        run: |
+          version=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Image tag: findmytakeover:$version"
+
+      - name: Build image
+        run: docker build -t "findmytakeover:${{ steps.ver.outputs.version }}" .
+
+      - name: Smoke test — entrypoint runs
+        run: docker run --rm "findmytakeover:${{ steps.ver.outputs.version }}" --help
+
+      - name: Smoke test — every cloud collector imports inside distroless
+        run: >-
+          docker run --rm --entrypoint /usr/bin/python3
+          "findmytakeover:${{ steps.ver.outputs.version }}"
+          -c "import findmytakeover, collector.aws, collector.gcp, collector.msazure, collector.cloudflare, collector.oracle; print('imports ok')"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # required for PyPI Trusted Publishing (OIDC)
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,22 +1,32 @@
-name: Publish to PyPI
+name: Publish
 
+# No release tags. The version lives in pyproject.toml:
+#   - push to main             -> publish that version to PyPI as a GA release
+#   - pull request (same repo) -> publish <version>.dev<run> to TestPyPI
 on:
   push:
-    tags:
-      - "v*"
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# One in-flight publish per ref; newer pushes supersede older ones.
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build-and-publish:
+  # ---- GA release: main -> PyPI ----------------------------------------
+  pypi-ga:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
-      id-token: write  # required for PyPI Trusted Publishing (OIDC)
+      id-token: write   # PyPI Trusted Publishing (OIDC)
+      contents: read
     steps:
-      - name: Check out the repository
-        uses: actions/checkout@v7
+      - uses: actions/checkout@v7
 
-      - name: Set up Python
-        uses: actions/setup-python@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.14"
 
@@ -27,3 +37,44 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # No-op instead of failing when pyproject's version wasn't bumped;
+          # bumping the version in pyproject.toml is what cuts a new GA release.
+          skip-existing: true
+
+  # ---- dev pre-release: PR -> TestPyPI ---------------------------------
+  testpypi-dev:
+    # Fork PRs can't get an OIDC token or environment secrets — same-repo only.
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.14"
+
+      - name: Stamp a unique .dev version
+        run: |
+          base=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          dev="${base}.dev${{ github.run_number }}"
+          # ephemeral edit on the runner only — never committed
+          sed -i "s/^version = \".*\"/version = \"${dev}\"/" pyproject.toml
+          echo "Building dev version ${dev}"
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,10 @@ jobs:
       id-token: write  # required for PyPI Trusted Publishing (OIDC)
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.14"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,32 @@
 FROM python:3.14-slim
 
+# Fail fast, no stray .pyc, no pip cache/version-check noise.
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_ROOT_USER_ACTION=ignore
+
 WORKDIR /app
 
-COPY . /app
+# Copy only what the package build needs (explicit, so local scan output /
+# credentials / config can never be baked into the image), install as root
+# into the system site-packages, then drop privileges for runtime.
+COPY pyproject.toml README.md LICENSE ./
+COPY findmytakeover.py ./
+COPY collector ./collector
 RUN pip install --no-cache-dir .
 
-# Config and cloud credentials are provided at runtime via volume mounts, e.g.:
+# Run as an unprivileged, no-login user (its home holds the mounted CLI creds).
+RUN useradd --create-home --shell /usr/sbin/nologin --uid 10001 scanner
+USER scanner
+
+# Config and read-only cloud credentials are supplied at runtime via mounts, e.g.:
 #   docker run --rm \
-#     -v "$PWD/findmytakeover.config:/app/findmytakeover.config" \
-#     -v "$HOME/.aws:/root/.aws:ro" \
+#     -v "$PWD/findmytakeover.config:/app/findmytakeover.config:ro" \
+#     -v "$HOME/.aws:/home/scanner/.aws:ro" \
+#     -v "$HOME/.config/gcloud:/home/scanner/.config/gcloud:ro" \
+#     -v "$HOME/.azure:/home/scanner/.azure:ro" \
 #     findmytakeover
 ENTRYPOINT ["findmytakeover"]
 CMD ["--config-file", "/app/findmytakeover.config"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,44 @@
-FROM python:3.14-slim
+# ---- build stage --------------------------------------------------------
+# Must match the distroless runtime's interpreter: distroless python3-debian12
+# ships Python 3.11, so build the wheels against 3.11 on the same (bookworm) libc.
+FROM python:3.11-slim-bookworm AS builder
 
-# Fail fast, no stray .pyc, no pip cache/version-check noise.
-ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1 \
-    PIP_NO_CACHE_DIR=1 \
+ENV PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_ROOT_USER_ACTION=ignore
 
-WORKDIR /app
+WORKDIR /src
 
 # Copy only what the package build needs (explicit, so local scan output /
-# credentials / config can never be baked into the image), install as root
-# into the system site-packages, then drop privileges for runtime.
+# credentials / config can never enter the image).
 COPY pyproject.toml README.md LICENSE ./
 COPY findmytakeover.py ./
 COPY collector ./collector
-RUN pip install --no-cache-dir .
 
-# Run as an unprivileged, no-login user (its home holds the mounted CLI creds).
-RUN useradd --create-home --shell /usr/sbin/nologin --uid 10001 scanner
-USER scanner
+# Install the app and all dependencies into one self-contained directory.
+RUN pip install --no-cache-dir --target=/packages .
+
+# ---- runtime stage ------------------------------------------------------
+# Distroless: no shell, no package manager, no root — just the interpreter and
+# our code. The :nonroot tag runs as uid 65532 with HOME=/home/nonroot.
+FROM gcr.io/distroless/python3-debian12:nonroot
+
+ENV PYTHONPATH=/packages \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+COPY --from=builder /packages /packages
+
+WORKDIR /app
 
 # Config and read-only cloud credentials are supplied at runtime via mounts, e.g.:
 #   docker run --rm \
 #     -v "$PWD/findmytakeover.config:/app/findmytakeover.config:ro" \
-#     -v "$HOME/.aws:/home/scanner/.aws:ro" \
-#     -v "$HOME/.config/gcloud:/home/scanner/.config/gcloud:ro" \
-#     -v "$HOME/.azure:/home/scanner/.azure:ro" \
+#     -v "$HOME/.aws:/home/nonroot/.aws:ro" \
+#     -v "$HOME/.config/gcloud:/home/nonroot/.config/gcloud:ro" \
+#     -v "$HOME/.azure:/home/nonroot/.azure:ro" \
 #     findmytakeover
-ENTRYPOINT ["findmytakeover"]
+#
+# No shell in the image — run the module with the image's own interpreter.
+ENTRYPOINT ["/usr/bin/python3", "-m", "findmytakeover"]
 CMD ["--config-file", "/app/findmytakeover.config"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.14-slim
+
+WORKDIR /app
+
+COPY . /app
+RUN pip install --no-cache-dir .
+
+# Config and cloud credentials are provided at runtime via volume mounts, e.g.:
+#   docker run --rm \
+#     -v "$PWD/findmytakeover.config:/app/findmytakeover.config" \
+#     -v "$HOME/.aws:/root/.aws:ro" \
+#     findmytakeover
+ENTRYPOINT ["findmytakeover"]
+CMD ["--config-file", "/app/findmytakeover.config"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ---- build stage --------------------------------------------------------
-# Must match the distroless runtime's interpreter: distroless python3-debian12
-# ships Python 3.11, so build the wheels against 3.11 on the same (bookworm) libc.
-FROM python:3.11-slim-bookworm AS builder
+# Must match the distroless runtime's interpreter: distroless python3-debian13
+# ships Python 3.13, so build the wheels against 3.13 on the same (trixie) libc.
+FROM python:3.13-slim-trixie AS builder
 
 ENV PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
@@ -21,7 +21,7 @@ RUN pip install --no-cache-dir --target=/packages .
 # ---- runtime stage ------------------------------------------------------
 # Distroless: no shell, no package manager, no root — just the interpreter and
 # our code. The :nonroot tag runs as uid 65532 with HOME=/home/nonroot.
-FROM gcr.io/distroless/python3-debian12:nonroot
+FROM gcr.io/distroless/python3-debian13:nonroot
 
 ENV PYTHONPATH=/packages \
     PYTHONDONTWRITEBYTECODE=1 \

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,0 +1,59 @@
+# Publishing
+
+Releases are **tag-free**. The package version lives in `pyproject.toml`, and
+`.github/workflows/publish.yml` decides what to publish from the event:
+
+| Event | Version built | Published to |
+| --- | --- | --- |
+| Push to `main` | `pyproject.toml` version (e.g. `1.0.0`) | **PyPI** (GA) |
+| Pull request (same repo, opened/updated) | `<version>.dev<run_number>` | **TestPyPI** (pre-release) |
+
+Fork PRs are skipped — they can't obtain an OIDC token. GA publishes use
+`skip-existing`, so merging to `main` without changing the version is a no-op
+rather than a failure.
+
+## Cutting a GA release
+
+No tags, no manual upload:
+
+1. Bump `version` in `pyproject.toml` (e.g. `1.0.0` → `1.0.1`).
+2. Merge to `main`.
+
+The push to `main` builds that version and publishes it to PyPI. To release
+again, bump the version again and merge again.
+
+## Dev builds
+
+Every push to an open PR (from a branch in this repo) publishes
+`<version>.dev<run_number>` to TestPyPI automatically — nothing to do. Install
+one for testing (deps come from real PyPI, since TestPyPI doesn't mirror them):
+
+```bash
+pip install --pre \
+  --index-url https://test.pypi.org/simple/ \
+  --extra-index-url https://pypi.org/simple/ \
+  findmytakeover
+```
+
+## One-time setup (required before the first publish)
+
+Uses [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC)
+— no API tokens or secrets stored in the repo.
+
+1. **GitHub environments** — create both (repo → Settings → Environments):
+   - `pypi`
+   - `testpypi`
+
+2. **PyPI trusted publisher** — on <https://pypi.org> → Account → Publishing →
+   *Add a pending publisher*:
+   - PyPI project name: `findmytakeover`
+   - Owner: `anirudhbiyani`
+   - Repository name: `findmytakeover`
+   - Workflow name: `publish.yml`
+   - Environment name: `pypi`
+
+3. **TestPyPI trusted publisher** — repeat on <https://test.pypi.org> with the
+   same values but **Environment name: `testpypi`**.
+
+"Pending publisher" is the right choice while the projects don't exist yet; the
+project is created automatically on first successful publish.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ This repo is also a Claude Code plugin marketplace, so the skill can be installe
 ## Limtitations 
 This tools cannot guarantee 100% protection against subdomain takeovers. Dangling NS delegations are detected only when they point at a cloud-provider nameserver pool (AWS/Azure/GCP) — delegations to other DNS providers can't be judged from cloud inventory alone.
 
+## Releasing
+
+Releases are tag-free: bump `version` in `pyproject.toml` and merge to `main` to
+publish a GA release to PyPI; open PRs auto-publish `.dev` builds to TestPyPI. See
+[PUBLISHING.md](PUBLISHING.md) for the flow and one-time trusted-publisher setup.
+
 ## Contributing
 
 You can contribute to the project in many ways either by reporting bugs, writting documentation, or adding code.


### PR DESCRIPTION
- Dockerfile (python:3.14-slim) that installs the package and runs the findmytakeover console command as entrypoint; config and cloud credentials are supplied at runtime via volume mounts.
- .dockerignore to keep build context lean.
- GitHub Actions workflow publishing to PyPI via Trusted Publishing (OIDC) on v* tag pushes.